### PR TITLE
fix(RUB-27418): fix workflow dispatch for polling status actions

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,9 @@ inputs:
   workflow:
     description: 'Name or ID of workflow to run'
     required: true
+  display-title:
+    description: 'Display title to filter the target workflow run'
+    required: false
   token:
     description: 'GitHub token with repo write access, can NOT use secrets.GITHUB_TOKEN, see readme'
     required: true

--- a/action.yaml
+++ b/action.yaml
@@ -64,6 +64,8 @@ outputs:
     description: 'ID of the triggered workflow'
   workflow-url:
     description: 'URL of the triggered workflow'
+  workflow-runs-found:
+    description: 'Number of workflow runs found (while searching for the triggered workflow run)'
   workflow-logs:
     description: |
       Logs of the triggered workflow. Based on `inputs.workflow-logs`, format is set to:

--- a/dist/index.js
+++ b/dist/index.js
@@ -29709,6 +29709,7 @@ class WorkflowHandler {
                     core.warning(`Found ${runs.length} runs. Using the last one.`);
                     yield this.debugFoundWorkflowRuns(runs);
                 }
+                core.setOutput('workflow-runs-found', runs.length);
                 this.workflowRunId = runs[0].id;
                 return this.workflowRunId;
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -29355,13 +29355,13 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const args = (0, utils_1.getArgs)();
-            core.info('Args: ' + JSON.stringify(args, null, 2));
             const workflowHandler = new workflow_handler_1.WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.runName, args.displayTitle);
             // Trigger workflow run
             yield workflowHandler.triggerWorkflow(args.inputs);
             core.info('Workflow triggered 🚀');
+            let url;
             if (args.displayWorkflowUrl) {
-                const url = yield getFollowUrl(workflowHandler, args.displayWorkflowUrlInterval, args.displayWorkflowUrlTimeout);
+                url = yield getFollowUrl(workflowHandler, args.displayWorkflowUrlInterval, args.displayWorkflowUrlTimeout);
                 core.info(`You can follow the running workflow here: ${url}`);
                 core.setOutput('workflow-url', url);
             }
@@ -29370,6 +29370,21 @@ function run() {
             }
             core.info('Waiting for workflow completion');
             const { result, start } = yield waitForCompletionOrTimeout(workflowHandler, args.checkStatusInterval, args.waitForCompletionTimeout);
+            if (url) {
+                yield core.summary
+                    .addHeading('🧪 Dev Deployment Workflow')
+                    .addLink('You can watch the workflow here', `${url}`)
+                    .addRaw(`Workflow run status: ${result === null || result === void 0 ? void 0 : result.status}`)
+                    .write()
+                    .catch(e => core.error(`Failed to write summary: ${e}`));
+            }
+            else {
+                yield core.summary
+                    .addHeading('🧪 Dev Deployment Workflow')
+                    .addRaw(`Workflow run status: ${result === null || result === void 0 ? void 0 : result.status}`)
+                    .write()
+                    .catch(e => core.error(`Failed to write summary: ${e}`));
+            }
             yield handleLogs(args, workflowHandler);
             core.setOutput('workflow-id', result === null || result === void 0 ? void 0 : result.id);
             core.setOutput('workflow-url', result === null || result === void 0 ? void 0 : result.url);

--- a/dist/index.js
+++ b/dist/index.js
@@ -29355,7 +29355,7 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const args = (0, utils_1.getArgs)();
-            core.info('Args: ' + args);
+            core.info('Args: ' + JSON.stringify(args, null, 2));
             const workflowHandler = new workflow_handler_1.WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.runName, args.displayTitle);
             // Trigger workflow run
             yield workflowHandler.triggerWorkflow(args.inputs);
@@ -29696,7 +29696,7 @@ class WorkflowHandler {
             }
             try {
                 let runs = yield this.findAllWorkflowRuns();
-                core.info(runs);
+                core.info('runs: ' + JSON.stringify(runs, null, 2));
                 if (this.runName) {
                     runs = runs.filter((r) => r.name == this.runName);
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -29359,9 +29359,8 @@ function run() {
             // Trigger workflow run
             yield workflowHandler.triggerWorkflow(args.inputs);
             core.info('Workflow triggered 🚀');
-            let url;
             if (args.displayWorkflowUrl) {
-                url = yield getFollowUrl(workflowHandler, args.displayWorkflowUrlInterval, args.displayWorkflowUrlTimeout);
+                const url = yield getFollowUrl(workflowHandler, args.displayWorkflowUrlInterval, args.displayWorkflowUrlTimeout);
                 core.info(`You can follow the running workflow here: ${url}`);
                 core.setOutput('workflow-url', url);
             }
@@ -29370,21 +29369,6 @@ function run() {
             }
             core.info('Waiting for workflow completion');
             const { result, start } = yield waitForCompletionOrTimeout(workflowHandler, args.checkStatusInterval, args.waitForCompletionTimeout);
-            if (url) {
-                yield core.summary
-                    .addHeading('🧪 Dev Deployment Workflow')
-                    .addLink('You can watch the workflow here', `${url}`)
-                    .addRaw(`Workflow run status: ${result === null || result === void 0 ? void 0 : result.status}`)
-                    .write()
-                    .catch(e => core.error(`Failed to write summary: ${e}`));
-            }
-            else {
-                yield core.summary
-                    .addHeading('🧪 Dev Deployment Workflow')
-                    .addRaw(`Workflow run status: ${result === null || result === void 0 ? void 0 : result.status}`)
-                    .write()
-                    .catch(e => core.error(`Failed to write summary: ${e}`));
-            }
             yield handleLogs(args, workflowHandler);
             core.setOutput('workflow-id', result === null || result === void 0 ? void 0 : result.id);
             core.setOutput('workflow-url', result === null || result === void 0 ? void 0 : result.url);
@@ -29711,7 +29695,6 @@ class WorkflowHandler {
             }
             try {
                 let runs = yield this.findAllWorkflowRuns();
-                core.info('runs: ' + JSON.stringify(runs, null, 2));
                 if (this.runName) {
                     runs = runs.filter((r) => r.name == this.runName);
                 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,7 @@ async function run(): Promise<void> {
 
     // Trigger workflow run
     await workflowHandler.triggerWorkflow(args.inputs)
-    core.info('Workflow triggered 🚀 ...')
+    core.info('Workflow triggered 🚀')
 
     if (args.displayWorkflowUrl) {
       const url = await getFollowUrl(workflowHandler, args.displayWorkflowUrlInterval, args.displayWorkflowUrlTimeout)

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,7 @@ async function handleLogs(args: any, workflowHandler: WorkflowHandler) {
 async function run(): Promise<void> {
   try {
     const args = getArgs()
-    core.info('Args: ' + args)
+    core.info('Args: ' + JSON.stringify(args, null, 2))
     const workflowHandler = new WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.runName, args.displayTitle)
 
     // Trigger workflow run

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,12 +75,12 @@ async function handleLogs(args: any, workflowHandler: WorkflowHandler) {
 async function run(): Promise<void> {
   try {
     const args = getArgs()
-    core.info('Args: ' + JSON.stringify(args, null, 2))
+    core.info('Args: ' + args)
     const workflowHandler = new WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.runName, args.displayTitle)
 
     // Trigger workflow run
     await workflowHandler.triggerWorkflow(args.inputs)
-    core.info('Workflow triggered 🚀')
+    core.info('Workflow triggered 🚀 ...')
 
     if (args.displayWorkflowUrl) {
       const url = await getFollowUrl(workflowHandler, args.displayWorkflowUrlInterval, args.displayWorkflowUrlTimeout)

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,6 +75,7 @@ async function handleLogs(args: any, workflowHandler: WorkflowHandler) {
 async function run(): Promise<void> {
   try {
     const args = getArgs()
+    core.info('Args: ' + JSON.stringify(args, null, 2))
     const workflowHandler = new WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.runName, args.displayTitle)
 
     // Trigger workflow run

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,9 +81,8 @@ async function run(): Promise<void> {
     await workflowHandler.triggerWorkflow(args.inputs)
     core.info('Workflow triggered 🚀')
 
-    let url
     if (args.displayWorkflowUrl) {
-      url = await getFollowUrl(workflowHandler, args.displayWorkflowUrlInterval, args.displayWorkflowUrlTimeout)
+      const url = await getFollowUrl(workflowHandler, args.displayWorkflowUrlInterval, args.displayWorkflowUrlTimeout)
       core.info(`You can follow the running workflow here: ${url}`)
       core.setOutput('workflow-url', url)
     }
@@ -94,21 +93,6 @@ async function run(): Promise<void> {
 
     core.info('Waiting for workflow completion')
     const { result, start } = await waitForCompletionOrTimeout(workflowHandler, args.checkStatusInterval, args.waitForCompletionTimeout)
-
-    if (url) {
-      await core.summary
-        .addHeading('🧪 Dev Deployment Workflow')
-        .addLink('You can watch the workflow here', `${url}`)
-        .addRaw(`Workflow run status: ${result?.status}`)
-        .write()
-        .catch(e => core.error(`Failed to write summary: ${e}`))
-    } else {
-      await core.summary
-        .addHeading('🧪 Dev Deployment Workflow')
-        .addRaw(`Workflow run status: ${result?.status}`)
-        .write()
-        .catch(e => core.error(`Failed to write summary: ${e}`))
-    }
 
     await handleLogs(args, workflowHandler)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,7 @@ async function handleLogs(args: any, workflowHandler: WorkflowHandler) {
 async function run(): Promise<void> {
   try {
     const args = getArgs()
-    const workflowHandler = new WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.runName)
+    const workflowHandler = new WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.runName, args.displayTitle)
 
     // Trigger workflow run
     await workflowHandler.triggerWorkflow(args.inputs)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,6 +51,7 @@ export function getArgs() {
   const checkStatusInterval = toMilliseconds(core.getInput('wait-for-completion-interval'))
   const runName = core.getInput('run-name')
   const workflowLogMode = core.getInput('workflow-logs')
+  const displayTitle = core.getInput('display-title')
 
   return {
     token,
@@ -66,7 +67,8 @@ export function getArgs() {
     waitForCompletion,
     waitForCompletionTimeout,
     runName,
-    workflowLogMode
+    workflowLogMode,
+    displayTitle
   }
 }
 

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -151,7 +151,7 @@ export class WorkflowHandler {
     }
     try {
       let runs = await this.findAllWorkflowRuns()
-      core.info(runs)
+      core.info('runs: ' + JSON.stringify(runs, null, 2))
       if (this.runName) {
         runs = runs.filter((r: any) => r.name == this.runName)
       }

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -146,18 +146,18 @@ export class WorkflowHandler {
   }
 
   async getWorkflowRunId(): Promise<number> {
-    // if (this.workflowRunId) {
-    //   return this.workflowRunId
-    // }
+    if (this.workflowRunId) {
+      return this.workflowRunId
+    }
     try {
       let runs = await this.findAllWorkflowRuns()
-      core.warning(runs)
+      core.info(runs)
       if (this.runName) {
         runs = runs.filter((r: any) => r.name == this.runName)
       }
 
       if (this.displayTitle) {
-        core.warning('Filtering by display title', this.displayTitle)
+        core.info('Filtering by display title: ' + this.displayTitle)
         runs = runs.filter((r: any) => r.display_title === this.displayTitle)
       }
 

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -150,6 +150,7 @@ export class WorkflowHandler {
     }
     try {
       let runs = await this.findAllWorkflowRuns()
+      console.log(runs[0])
       if (this.runName) {
         runs = runs.filter((r: any) => r.name == this.runName)
       }

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -54,7 +54,8 @@ export class WorkflowHandler {
     private owner: string,
     private repo: string,
     private ref: string,
-    private runName: string) {
+    private runName: string,
+    private displayTitle?: string) {
     // Get octokit client for making API calls
     this.octokit = github.getOctokit(token)
   }
@@ -150,9 +151,14 @@ export class WorkflowHandler {
     }
     try {
       let runs = await this.findAllWorkflowRuns()
-      console.log(runs[0])
+      console.log(runs)
       if (this.runName) {
         runs = runs.filter((r: any) => r.name == this.runName)
+      }
+
+      if (this.displayTitle) {
+        console.log('Filtering by display title', this.displayTitle)
+        runs = runs.filter((r: any) => r.display_title === this.displayTitle)
       }
 
       if (runs.length == 0) {

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -151,13 +151,13 @@ export class WorkflowHandler {
     }
     try {
       let runs = await this.findAllWorkflowRuns()
-      console.log(runs)
+      core.info(runs)
       if (this.runName) {
         runs = runs.filter((r: any) => r.name == this.runName)
       }
 
       if (this.displayTitle) {
-        console.log('Filtering by display title', this.displayTitle)
+        core.info('Filtering by display title', this.displayTitle)
         runs = runs.filter((r: any) => r.display_title === this.displayTitle)
       }
 

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -151,13 +151,13 @@ export class WorkflowHandler {
     }
     try {
       let runs = await this.findAllWorkflowRuns()
-      core.info(runs)
+      core.warning(runs)
       if (this.runName) {
         runs = runs.filter((r: any) => r.name == this.runName)
       }
 
       if (this.displayTitle) {
-        core.info('Filtering by display title', this.displayTitle)
+        core.warning('Filtering by display title', this.displayTitle)
         runs = runs.filter((r: any) => r.display_title === this.displayTitle)
       }
 

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -170,6 +170,7 @@ export class WorkflowHandler {
         await this.debugFoundWorkflowRuns(runs)
       }
 
+      core.setOutput('workflow-runs-found', runs.length)
       this.workflowRunId = runs[0].id as number
 
       return this.workflowRunId

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -151,7 +151,7 @@ export class WorkflowHandler {
     }
     try {
       let runs = await this.findAllWorkflowRuns()
-      core.info('runs: ' + JSON.stringify(runs, null, 2))
+
       if (this.runName) {
         runs = runs.filter((r: any) => r.name == this.runName)
       }

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -146,9 +146,9 @@ export class WorkflowHandler {
   }
 
   async getWorkflowRunId(): Promise<number> {
-    if (this.workflowRunId) {
-      return this.workflowRunId
-    }
+    // if (this.workflowRunId) {
+    //   return this.workflowRunId
+    // }
     try {
       let runs = await this.findAllWorkflowRuns()
       core.warning(runs)


### PR DESCRIPTION
## What?
Add the capability to filter the workflows by name when searching for the workflow link.

## Why?
If multiple workflows are triggered, it returns only the first one on the list.